### PR TITLE
fix readCurrentState and readTargetState

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,12 @@ function HttpSecuritySystemAccessory(log, config) {
 			body: config.urls.disarm.body
 		},
 		readCurrentState: {
-			url: config.urls.read.url,
-			body: config.urls.read.body
+			url: config.urls.readCurrentState.url,
+			body: config.urls.readCurrentState.body
 		},
 		readTargetState: {
-			url: config.urls.read.url,
-			body: config.urls.read.body
+			url: config.urls.readTargetState.url,
+			body: config.urls.readTargetState.body
 		}
 	};
 	


### PR DESCRIPTION
readCurrentState and readTargetState attempt to access unassigned objects based on the expected configuration